### PR TITLE
Fix #23: Data Adapter does not start on Wildfly AS

### DIFF
--- a/powerauth-data-adapter/pom.xml
+++ b/powerauth-data-adapter/pom.xml
@@ -78,6 +78,13 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
 
+        <!-- Set scope of tomcat-embed-websocket to provided to avoid startup errors on WildFly -->
+        <dependency>
+            <artifactId>tomcat-embed-websocket</artifactId>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- PowerAuth Dependencies -->
         <dependency>
             <groupId>io.getlime.security</groupId>


### PR DESCRIPTION
I excluded the tomcat-embed-websocket artifact in pom.xml, there is no class conflict anymore and Data Adapter runs on Wildfly AS.